### PR TITLE
Add `plan` to optional properties

### DIFF
--- a/lib/amplitude_api/config.rb
+++ b/lib/amplitude_api/config.rb
@@ -33,7 +33,7 @@ class AmplitudeAPI
           carrier region city dma language
           location_lat location_lng
           idfa idfv adid android_id
-          event_id session_id
+          event_id session_id plan
         ]
       end
 


### PR DESCRIPTION
We want to pass `plan: { branch: "some name" }` as part of the payload,
but since this isn't a whitelisted property, AmplitudeAPI ends up
creating accessors dynamically. This has a bug: only first
initialization actually adds `plan` to the payload, subsequent events
don't have this value. To work around it, we're extending the list of
properties itself, which isn't possible to do with current config setup.